### PR TITLE
amp-iframe support + fix $post warning (3.19.1)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: winrid
 Tags: comments, comment form, commenting system, live comments, disqus
 Requires at least: 4.6
 Tested up to: 6.9.2
-Stable tag: 3.19.0
+Stable tag: 3.19.1
 Requires PHP: 5.2.5
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -132,6 +132,10 @@ Yes. You can cancel without any intervention from customer support. Your comment
 6. Simple WordPress admin panel
 
 == Changelog ==
+
+= 3.19.1 =
+* Render comments in an amp-iframe on AMP pages (e.g. with the AMP or Newspack plugins), where custom JavaScript is stripped.
+* Fixed a PHP warning ("Undefined variable $post") when the comments widget renders via the block editor's comments block.
 
 = 3.19.0 =
 * Adds new widgets available in block editor.

--- a/fastcomments-wordpress-plugin.php
+++ b/fastcomments-wordpress-plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: FastComments
 Plugin URI: https://fastcomments.com
 Description: A live, fast, privacy-focused commenting system with advanced spam prevention capabilities.
-Version: 3.19.0
+Version: 3.19.1
 Author: winrid @ FastComments
 License: GPL-2.0+
 */
@@ -13,7 +13,7 @@ if (!defined('WPINC')) {
     die;
 }
 
-$FASTCOMMENTS_VERSION = 3.190;
+$FASTCOMMENTS_VERSION = 3.191;
 
 require_once plugin_dir_path(__FILE__) . 'admin/fastcomments-admin.php';
 require_once plugin_dir_path(__FILE__) . 'public/fastcomments-public.php';

--- a/public/fastcomments-widget-view.php
+++ b/public/fastcomments-widget-view.php
@@ -1,3 +1,4 @@
+<?php global $post; ?>
 <div id="fastcomments-widget"></div>
 <?php
     if (!get_option('fastcomments_tenant_id') && current_user_can('activate_plugins')) {
@@ -11,39 +12,9 @@
         global $FASTCOMMENTS_VERSION;
         $cdn = FastCommentsPublic::getCDN();
         $site = FastCommentsPublic::getSite();
-        $widgetType = get_option('fastcomments_widget');
-        $constructorName = $widgetType === "1" ? 'FastCommentsLiveChat' : 'FastCommentsUI';
-        $scriptName = $widgetType === "1" ? 'embed-live-chat' : 'embed-v2';
-        wp_enqueue_script( 'fastcomments_widget_embed', "$cdn/js/$scriptName.min.js", array(), $FASTCOMMENTS_VERSION, false );
-        global $post;
         $config = FastCommentsPublic::get_config_for_post($post);
         $jsonFcConfig = json_encode($config);
         $urlId = $config['urlId'];
-        // These "fcInitializedById" checks are for plugins that try to load the comments more than once for the same url id.
-        // The repeated attempt to load is to handle plugins that make our embed script async.
-        $script = "
-            (function() {
-                if (!window.fcInitializedById) {
-                    window.fcInitializedById = {};
-                }
-                if (window.fcInitializedById['$urlId']) {
-                    return;
-                }
-                window.fcInitializedById['$urlId'] = true;
-                var attempts = 0;
-                function attemptToLoad() {
-                    attempts++;
-                    var widgetTarget = document.getElementById('fastcomments-widget'); 
-                    if (window.$constructorName && widgetTarget) {
-                        window.$constructorName(widgetTarget, $jsonFcConfig);
-                        return;
-                    }
-                    setTimeout(attemptToLoad, attempts > 50 ? 500 : 50);
-                }
-                attemptToLoad();
-            })();
-        ";
-        wp_add_inline_script('fastcomments_widget_embed', $script);
 
         $tenantIdEncoded = rawurlencode($config['tenantId']);
         $urlEncoded = rawurlencode($config['url']);
@@ -52,19 +23,66 @@
             $sso_query_string = rawurlencode(json_encode($config['sso']));
             $fastcomments_url = $fastcomments_url . "&sso=$sso_query_string";
         }
-        ?>
-        <noscript>
-            <iframe
-                    src="<?php echo $fastcomments_url; ?>"
-                    horizontalscrolling="no"
-                    allowtransparency="true"
+
+        // AMP strips custom JS, so render the server-side comments in an amp-iframe instead of the JS widget.
+        $is_amp = (function_exists('amp_is_request') && amp_is_request()) || (function_exists('is_amp_endpoint') && is_amp_endpoint());
+        if ($is_amp) {
+            ?>
+            <amp-iframe
+                    src="<?php echo esc_url($fastcomments_url); ?>"
+                    width="auto"
+                    height="1500"
+                    layout="fixed-height"
+                    sandbox="allow-scripts allow-same-origin allow-popups allow-forms allow-popups-to-escape-sandbox"
                     frameborder="0"
-                    title="FastComments"
-                    width="100%"
-                    height="1500px"
-                    style="width: 1px !important; min-width: 100% !important; border: none !important; overflow: hidden !important;"
-            ></iframe>
-        </noscript>
-        <?php
+                    title="FastComments">
+                <div placeholder>Loading comments&hellip;</div>
+            </amp-iframe>
+            <?php
+        } else {
+            $widgetType = get_option('fastcomments_widget');
+            $constructorName = $widgetType === "1" ? 'FastCommentsLiveChat' : 'FastCommentsUI';
+            $scriptName = $widgetType === "1" ? 'embed-live-chat' : 'embed-v2';
+            wp_enqueue_script( 'fastcomments_widget_embed', "$cdn/js/$scriptName.min.js", array(), $FASTCOMMENTS_VERSION, false );
+            // These "fcInitializedById" checks are for plugins that try to load the comments more than once for the same url id.
+            // The repeated attempt to load is to handle plugins that make our embed script async.
+            $script = "
+                (function() {
+                    if (!window.fcInitializedById) {
+                        window.fcInitializedById = {};
+                    }
+                    if (window.fcInitializedById['$urlId']) {
+                        return;
+                    }
+                    window.fcInitializedById['$urlId'] = true;
+                    var attempts = 0;
+                    function attemptToLoad() {
+                        attempts++;
+                        var widgetTarget = document.getElementById('fastcomments-widget');
+                        if (window.$constructorName && widgetTarget) {
+                            window.$constructorName(widgetTarget, $jsonFcConfig);
+                            return;
+                        }
+                        setTimeout(attemptToLoad, attempts > 50 ? 500 : 50);
+                    }
+                    attemptToLoad();
+                })();
+            ";
+            wp_add_inline_script('fastcomments_widget_embed', $script);
+            ?>
+            <noscript>
+                <iframe
+                        src="<?php echo $fastcomments_url; ?>"
+                        horizontalscrolling="no"
+                        allowtransparency="true"
+                        frameborder="0"
+                        title="FastComments"
+                        width="100%"
+                        height="1500px"
+                        style="width: 1px !important; min-width: 100% !important; border: none !important; overflow: hidden !important;"
+                ></iframe>
+            </noscript>
+            <?php
+        }
     }
 ?>


### PR DESCRIPTION
## Summary

Two changes, both surfaced while testing the plugin against the Newspack plugin/theme on WordPress 7.0:

1. **AMP support via `amp-iframe`.** On AMP pages the JS embed (`embed-v2.min.js` + inline init) is stripped by AMP, and the previous `<noscript><iframe>` fallback is not valid AMP, so comments did not render. The widget view now detects AMP (`amp_is_request()` / `is_amp_endpoint()`) and outputs an `<amp-iframe>` pointing at the existing server-side `/ssr/comments` endpoint. The JS path is unchanged for non-AMP pages.

2. **Fix `Undefined variable $post` warning.** `public/fastcomments-widget-view.php` used `$post` (in `post_password_required($post)`) before declaring `global $post`. Via the classic `comments_template()` path `$post` is in scope, but via the block editor's `core/comments` path (`pre_render_block` -> `require`) it is not, producing a PHP warning on every block-theme render. `global $post` is now hoisted to the top of the file.

Bumped to `3.19.1` (header, `$FASTCOMMENTS_VERSION`, README stable tag + changelog).

## Verification

Tested in a local Dockerized WordPress 7.0 install with FastComments (tenant `demo`) + Newspack plugin v6.42.0 + Newspack theme v2.22.2.

- **Block theme (Twenty Twenty-Five):** `$post` warning gone after the fix; widget still renders.
- **Newspack classic theme (non-AMP):** widget renders via the `comments_template` filter, confirmed in a real browser.
- **AMP (official AMP plugin v2.5.5, transitional mode):** the post serves a valid AMP document; the `<amp-iframe>` is emitted, accepted, and laid out by the AMP runtime (auto-injects the `amp-iframe` component script). AMP dev mode (`#development=1`) logs **"AMP validation successful."** and the comments render inside the iframe.

### `amp-iframe` notes
- `layout="fixed-height"` with `width="auto"` so it spans the container at a fixed height (1500px, matching the old noscript fallback).
- Includes a `placeholder` child so it is valid regardless of vertical position on the page.
- `sandbox` permits scripts/forms/popups; `allow-same-origin` is safe here since the iframe origin (fastcomments.com) differs from the host site.
- The AMP plugin auto-adds the required `<script custom-element="amp-iframe">`, so no manual enqueue is needed.